### PR TITLE
Use work.bin files directly.

### DIFF
--- a/pkg2zip.c
+++ b/pkg2zip.c
@@ -738,7 +738,11 @@ int main(int argc, char* argv[])
 
         if (type != PKG_TYPE_VITA_PATCH && zrif_arg != NULL)
         {
-            zrif_decode(zrif_arg, rif, rif_size);
+            if (str_endswith(zrif_arg, ".bin")) {
+                rif_load(zrif_arg, rif, rif_size);
+            } else {
+                zrif_decode(zrif_arg, rif, rif_size);
+            }
             const char* rif_contentid = (char*)rif + (type == PKG_TYPE_VITA_PSM ? 0x50 : 0x10);
             if (strncmp(rif_contentid, content, 0x30) != 0)
             {

--- a/pkg2zip_utils.h
+++ b/pkg2zip_utils.h
@@ -2,6 +2,8 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
+#include <stdbool.h>
 
 #if defined(_MSC_VER)
 #  define NORETURN __declspec(noreturn)
@@ -115,4 +117,13 @@ static inline void set64be(uint8_t* bytes, uint64_t x)
     bytes[5] = (uint8_t)(x >> 16);
     bytes[6] = (uint8_t)(x >> 8);
     bytes[7] = (uint8_t)x;
+}
+
+static inline bool str_endswith(const char* str, const char* suffix) {
+    const size_t suffix_len = strlen(suffix);
+    const size_t str_len = strlen(str);
+    if (str_len < suffix_len) return false;
+
+    const char *str_end = str + (str_len - suffix_len);
+    return strcmp(str_end, suffix) == 0;
 }

--- a/pkg2zip_zrif.c
+++ b/pkg2zip_zrif.c
@@ -5,6 +5,7 @@
 #include "puff.h"
 
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
 
 #define ADLER32_MOD 65521
@@ -172,4 +173,10 @@ void zrif_decode(const char* str, uint8_t* rif, uint32_t rif_size)
     }
 
     memcpy(rif, out, rif_size);
+}
+
+void rif_load(const char* str, uint8_t* rif, uint32_t rif_size) {
+    FILE *file = fopen(str, "rb");
+    fread(rif, rif_size, 1, file);
+    fclose(file);
 }

--- a/pkg2zip_zrif.h
+++ b/pkg2zip_zrif.h
@@ -3,3 +3,4 @@
 #include <stdint.h>
 
 void zrif_decode(const char* str, uint8_t* rif, uint32_t rif_size);
+void rif_load(const char* str, uint8_t* rif, uint32_t rif_size);


### PR DESCRIPTION
This PR allows the user to decrypt .pkg files using work.bin files directly instead of requiring conversion from bin -> zRIF.
Note: Only implemented for PSVita so far.